### PR TITLE
Store bridge address protocol

### DIFF
--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/NetworkMethods.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/api/NetworkMethods.java
@@ -25,7 +25,7 @@ public class NetworkMethods {
     Gson gson = new Gson();
 
     String url =
-        "http://" + route.address + "/api/" + hash + "/lights/" + pState.hubBulb.getHubBulbNumber()
+        route.address + "/api/" + hash + "/lights/" + pState.hubBulb.getHubBulbNumber()
         + "/state";
 
     GsonRequest<LightsPutResponse[]> req =
@@ -45,7 +45,7 @@ public class NetworkMethods {
       return;
     }
 
-    String url = "http://" + route.address + "/api/" + hash + "/lights/" + bulb;
+    String url = route.address + "/api/" + hash + "/lights/" + bulb;
 
     GsonRequest<BulbAttributes> req =
         new GsonRequest<BulbAttributes>(Method.GET, url, null, BulbAttributes.class, null,
@@ -65,7 +65,7 @@ public class NetworkMethods {
     }
 
     Gson gson = new Gson();
-    String url = "http://" + route.address + "/api/" + hash + "/lights/" + bulbNum;
+    String url = route.address + "/api/" + hash + "/lights/" + bulbNum;
 
     GsonRequest<LightsPutResponse[]> req =
         new GsonRequest<>(Method.PUT, url, gson.toJson(bulbAtt.getSettableAttributes()),
@@ -85,7 +85,7 @@ public class NetworkMethods {
       return;
     }
 
-    String url = "http://" + route.address + "/api/" + hash + "/lights";
+    String url = route.address + "/api/" + hash + "/lights";
 
     GsonRequest<BulbList> req =
         new GsonRequest<BulbList>(Method.GET, url, null, BulbList.class, null,
@@ -112,7 +112,7 @@ public class NetworkMethods {
 
     for (int i = 0; i < bridges.length; i++) {
 
-      String url = "http://" + bridges[i].internalipaddress + "/api/";
+      String url = bridges[i].internalipaddress + "/api/";
 
       GsonRequest<RegistrationResponse[]> req =
           new GsonRequest<RegistrationResponse[]>(Method.POST, url, registrationRequest,

--- a/mobile/src/main/java/com/kuxhausen/huemore/net/hue/ui/ConfigureHubDialogFragment.java
+++ b/mobile/src/main/java/com/kuxhausen/huemore/net/hue/ui/ConfigureHubDialogFragment.java
@@ -55,8 +55,19 @@ public class ConfigureHubDialogFragment extends DialogFragment {
       @Override
       public void onClick(DialogInterface dialog, int id) {
         HubData hd = new HubData();
-        hd.localHubAddress = mLocalAddress.getText().toString();
-        hd.portForwardedAddress = mRemoteAddress.getText().toString();
+        String localAddress = mLocalAddress.getText().toString();
+        String remoteAddress = mRemoteAddress.getText().toString();
+        
+        if (!localAddress.matches("(?i:https?:).*")) {
+          localAddress = "http://" + localAddress;
+        }
+        
+        if (!remoteAddress.matches("(?i:https?:).*")) {
+          remoteAddress = "http://" + remoteAddress;
+        }
+        
+        hd.localHubAddress = localAddress;
+        hd.portForwardedAddress = remoteAddress;
 
         if (mPriorConnection != null) {
           hd.hashedUsername = mPriorConnection.getHubData().hashedUsername;


### PR DESCRIPTION
I didn't look at your code closely enough to see where I need to put 'upgrade' code for data stored in the old format. Do you mind doing that part yourself? Just check if the currently stored value matches `(?i:https?:).*`, and if not prepend `http://` and save the new value.

I want this so I can use my bridge at [eligrey.com/hue](https://eligrey.com/hue/api) over https.
